### PR TITLE
Use hooks

### DIFF
--- a/lib/interfaces/plug.ts
+++ b/lib/interfaces/plug.ts
@@ -1,13 +1,3 @@
 import { Observable } from "rxjs";
 
 export type TStream = (stream: any) => Observable<any>;
-
-export interface ILifecycle {
-  componentDidMount: () => void;
-  componentWillUnmount: () => void;
-}
-
-export interface IPlugState {
-  hasEmmited: boolean;
-  innerData?: any;
-}


### PR DESCRIPTION
In this branch I replaced the plug HOC implementation to use **react hooks**, I've used **useState** e **useEffect** and eliminated unnecessary code. I'd also removed the lifecycle object that we received, because since we use **hooks** now, whoever uses the plug can implement **useEffect** in his functional components instead of passing it to us, so the person using the plug HOC has more control of his implementation